### PR TITLE
增加通用性 修复bug

### DIFF
--- a/md.zsh
+++ b/md.zsh
@@ -10,11 +10,11 @@ MD_EXCLUDE_FILE="$HOME/.md/exclude"
 _MD_MAX_SIZE=$((32 * 1024 * 1024))
 
 # 默认排除列表（仅交互式命令）
-_MD_DEFAULT_EXCLUDE='md|mdd|clear|reset|exit|fg|bg|vim|vi|nano|less|more|top|htop|man|ssh|nload|iftop|watch|journalctl|tmux|screen|emacs|nvim|mc|ranger|lazygit|tig|fzf|ls|ll'
+_MD_DEFAULT_EXCLUDE="$MD_CMD_NAME"'|clear|reset|exit|fg|bg|vim|vi|nano|less|more|top|htop|man|ssh|nload|iftop|watch|journalctl|tmux|screen|emacs|nvim|mc|ranger|lazygit|tig|fzf|ls|ll'
 
 # JetBrains 终端不支持，直接禁用
 if [[ "$TERMINAL_EMULATOR" == *"JetBrains"* ]]; then
-    md() { echo "md: not supported in JetBrains terminal" >&2; return 1; }
+    $MD_CMD_NAME() { echo "md: not supported in JetBrains terminal" >&2; return 1; }
     return 0
 fi
 
@@ -75,6 +75,9 @@ _md_copy() {
             printf '%s' "$input" | xclip -selection clipboard && return 0
         elif command -v xsel &>/dev/null; then
             printf '%s' "$input" | xsel --clipboard && return 0
+        elif command -v termux-clipboard-set &>/dev/null; then
+            # 适配 Termux 用户
+            termux-clipboard-set "$input"
         fi
     fi
 


### PR DESCRIPTION
**增加通用性: 修改 md|mmd 的硬编码配置为 $MD_CMD_NAME 变量**

``` diff
@@ -13,1 +13,1 @@  # 默认排除列表（仅交互式命令）
-_MD_DEFAULT_EXCLUDE='md|mdd|clear|reset|exit|fg|bg|vim|vi|nano|less|more|top|htop|man|ssh|nload|iftop|watch|journalctl|tmux|screen|emacs|nvim|mc|ranger|lazygit|tig|fzf|ls|ll'
+_MD_DEFAULT_EXCLUDE="$MD_CMD_NAME"'|clear|reset|exit|fg|bg|vim|vi|nano|less|more|top|htop|man|ssh|nload|iftop|watch|journalctl|tmux|screen|emacs|nvim|mc|ranger|lazygit|tig|fzf|ls|ll'
```

这使用户无论使用什么自定义名称，都可以正常排除掉自身

**修复 bug: 将硬编码的函数名称修改为使用 $MD_CMD_NAME 变量**

``` diff
@@ -16,1 +16,1 @@  if [[ "$TERMINAL_EMULATOR" == *"JetBrains"* ]]; then
-    md() { echo "md: not supported in JetBrains terminal" >&2; return 1; }
+    $MD_CMD_NAME() { echo "md: not supported in JetBrains terminal" >&2; return 1; }
```

这使在安装了 Oh My Zsh 的 Zsh 终端中如果使用自定义名称，则不会因为受到 Oh My Zsh 的 `alias md='mkdir -p` 的影响而抛出 ``defining function based on alias `md'`` 错误

同时如果使用自定义名称在 JetBrains 中安装，修复 Bug 之前，运行 md 会抛出错误，但是运行自定义名称依然会运行复制逻辑并导致卡死

**增加通用性: 增加 Termux 终端模拟器的原生复制命令支持**

``` diff
@@ -78,1 +78,4 @@ printf '%s' "$input" | xsel --clipboard && return 0
+        elif command -v termux-clipboard-set &>/dev/null; then
+            # 适配 Termux 用户
+            termux-clipboard-set "$input"
```